### PR TITLE
add jinja2 templating

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ Usage
       --follow-children              Follow threads linked in downloaded threads
       --follow-to-other-boards       Follow linked threads, even if from other boards
       --silent                       Suppresses mundane printouts, prints what's important
+      --jinja2                       Use new jinja2 templating instead of downloading HTML
       -v --verbose                   Printout more information than normal
       -h --help                      Show help
       -V --version                   Show version

--- a/basc_archiver/__init__.py
+++ b/basc_archiver/__init__.py
@@ -21,7 +21,8 @@ class Options:
                  skip_thumbs=False, thumbs_only=False,
                  skip_js=False, skip_css=False,
                  follow_child_threads=False, follow_to_other_boards=False,
-                 run_once=False,):
+                 run_once=False,
+                 jinja2=False,):
         self.base_dir = base_dir
         self.use_ssl = use_ssl
         self.silent = silent
@@ -37,6 +38,7 @@ class Options:
         self.follow_child_threads = follow_child_threads
         self.follow_to_other_boards = follow_to_other_boards
         self.run_once = run_once
+        self.jinja2 = jinja2
 
 
 class Archiver:

--- a/basc_archiver/sites/base.py
+++ b/basc_archiver/sites/base.py
@@ -82,7 +82,7 @@ class BaseSiteArchiver(object):
             raise Exception('BaseSiteArchiver must be subclassed!')
         self.options = options
         self.base_thread_dir = os.path.join(options.base_dir,
-                                            '{}/{{board}}/{{thread}}/'.format(self.name))
+                                            '{{board}}/thread/{{thread}}/'.format())
         self.base_images_dir = os.path.join(self.base_thread_dir, 'images')
         self.base_thumbs_dir = os.path.join(self.base_thread_dir, 'thumbs')
 

--- a/basc_archiver/sites/fourchan.py
+++ b/basc_archiver/sites/fourchan.py
@@ -7,12 +7,17 @@ from __future__ import absolute_import
 from .base import BaseSiteArchiver
 from .. import utils
 
+from htmlmin.minify import html_minify
+
 import basc_py4chan
 
 import os
 import re
 import codecs
 import threading
+
+import jinja2
+import json
 
 THREAD_NONEXISTENT = 'Thread {site} / {board} / {thread_id} does not exist.'
 THREAD_NONEXISTENT_REASON = ("Either the thread already 404'ed, your URL is incorrect, "
@@ -309,39 +314,58 @@ class FourChanSiteArchiver(BaseSiteArchiver):
 
             # and output thread html file
             local_filename = os.path.join(thread_dir, '{}.html'.format(thread_id))
-            url = http_header + FOURCHAN_BOARDS_URL % (board_name, thread_id)
 
-            if utils.download_file(local_filename, url, clobber=True):
-                # get css files
-                if not self.options.skip_css:
-                    css_dir = os.path.join(thread_dir, _CSS_DIR_NAME)
-                    utils.mkdirs(css_dir)
+            # new jinja2 templating
+            if self.options.jinja2:
+                json_data = open(local_filename.replace(".html", ".json"))
+                data = json.load(json_data)
+                templateEnv = jinja2.Environment(loader=jinja2.PackageLoader('basc_archiver.sites'))
+                template = templateEnv.get_template('template.html')
+                outputText = template.render(posts=data)
 
-                    css_regex = re.compile(FOURCHAN_CSS_REGEX)
-                    found_css_files = css_regex.findall(codecs.open(local_filename, encoding='utf-8').read())
-                    for css_filename in found_css_files:
-                        local_css_filename = os.path.join(css_dir, css_filename)
-                        url = http_header + FOURCHAN_STATIC + '/css/' + css_filename
-                        utils.download_file(local_css_filename, url)
+                minified_html = html_minify(outputText)
 
-                # get js files
-                if not self.options.skip_js:
-                    js_dir = os.path.join(thread_dir, _JS_DIR_NAME)
-                    utils.mkdirs(js_dir)
+                f = open(local_filename, "w")
+                f.write(minified_html.encode('utf-8'))
+                f.close()
 
-                    js_regex = re.compile(FOURCHAN_JS_REGEX)
-                    found_js_files = js_regex.findall(codecs.open(local_filename, encoding='utf-8').read())
-                    for js_filename in found_js_files:
-                        local_js_filename = os.path.join(js_dir, js_filename)
-                        url = http_header + FOURCHAN_STATIC + '/js/' + js_filename
-                        utils.download_file(local_js_filename, url)
+                print('  Thread HTML Generated')
 
-                # convert links to local links
-                utils.file_replace(local_filename, '"//', '"' + http_header)
-                utils.file_replace(local_filename, FOURCHAN_IMAGES_URL_REGEX, _IMAGE_DIR_NAME + r'/\1')
-                utils.file_replace(local_filename, FOURCHAN_THUMBS_URL_REGEX, _THUMB_DIR_NAME + r'/\1')
-                utils.file_replace(local_filename, FOURCHAN_CSS_URL_REGEX, _CSS_DIR_NAME + '/')
-                utils.file_replace(local_filename, FOURCHAN_JS_URL_REGEX, _JS_DIR_NAME + '/')
+            # old html downloading
+            else:
+                url = http_header + FOURCHAN_BOARDS_URL % (board_name, thread_id)
+
+                if utils.download_file(local_filename, url, clobber=True):
+                    # get css files
+                    if not self.options.skip_css:
+                        css_dir = os.path.join(thread_dir, _CSS_DIR_NAME)
+                        utils.mkdirs(css_dir)
+
+                        css_regex = re.compile(FOURCHAN_CSS_REGEX)
+                        found_css_files = css_regex.findall(codecs.open(local_filename, encoding='utf-8').read())
+                        for css_filename in found_css_files:
+                            local_css_filename = os.path.join(css_dir, css_filename)
+                            url = http_header + FOURCHAN_STATIC + '/css/' + css_filename
+                            utils.download_file(local_css_filename, url)
+
+                    # get js files
+                    if not self.options.skip_js:
+                        js_dir = os.path.join(thread_dir, _JS_DIR_NAME)
+                        utils.mkdirs(js_dir)
+
+                        js_regex = re.compile(FOURCHAN_JS_REGEX)
+                        found_js_files = js_regex.findall(codecs.open(local_filename, encoding='utf-8').read())
+                        for js_filename in found_js_files:
+                            local_js_filename = os.path.join(js_dir, js_filename)
+                            url = http_header + FOURCHAN_STATIC + '/js/' + js_filename
+                            utils.download_file(local_js_filename, url)
+
+                    # convert links to local links
+                    utils.file_replace(local_filename, '"//', '"' + http_header)
+                    utils.file_replace(local_filename, FOURCHAN_IMAGES_URL_REGEX, _IMAGE_DIR_NAME + r'/\1')
+                    utils.file_replace(local_filename, FOURCHAN_THUMBS_URL_REGEX, _THUMB_DIR_NAME + r'/\1')
+                    utils.file_replace(local_filename, FOURCHAN_CSS_URL_REGEX, _CSS_DIR_NAME + '/')
+                    utils.file_replace(local_filename, FOURCHAN_JS_URL_REGEX, _JS_DIR_NAME + '/')
 
             # add images to dl queue
             for filename in thread['thread'].filenames():

--- a/basc_archiver/sites/templates/template.html
+++ b/basc_archiver/sites/templates/template.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<head>
+  <meta charset="utf-8">
+  <script type="text/javascript">var  style_group = "ws_style",  cssVersion = 638,  jsVersion = 1015,  comlen = 2000,  maxFilesize = 4194304,  maxLines = 100,  file_too_big = "Error: Maximum file size allowed is 4096 KB.",  clickable_ids = 1,  cooldowns = {"thread":600,"reply":30,"image":60,"reply_intra":60,"image_intra":60};var unique_ips = 1;var maxWebmFilesize = 3145728;var board_archived = true;var check_for_block = 1; blockPlea = 'Please <a class="aplnk" href="//www.4chan.org/news?all#109" target="_blank">support 4chan</a> by disabling your ad blocker on *.4chan.org/*, <a class="aplnk" href="https://www.4chan.org/advertise?selfserve" target="_blank">purchasing a self-serve ad</a>, or <a class="aplnk" href="https://www.4chan.org/pass" target="_blank">buying a 4chan Pass</a>.';</script>
+  <link rel="stylesheet" type="text/css" href="/css/tomorrow.638.css">
+  <!--script type="text/javascript" data-cfasync="false" src="js/core.js"></script-->
+  <script type="text/javascript" data-cfasync="false" src="/js/extension.1014.js"></script>
+  <link rel="shortcut icon" href="/image/favicon-ws-deadthread.ico" type="image/x-icon">
+</head>
+<body class="tomorrow ws">
+<div id="delform">
+<div class="board">
+<div id="boardNavDesktop" class="desktop"><span id="navtopright">[<a href="javascript:void(0);" id="settingsWindowLink">Settings</a>]</span></div>
+<div id="boardNavMobile" class="mobile"> <div class="boardSelect"> <strong>Board</strong> <select id="boardSelectMobile"></select> </div> <div class="pageJump"> <a href="#bottom">▼</a> <a href="javascript:void(0);" id="settingsWindowLinkMobile">Settings</a> <a href="http://www.4chan.org" target="_top">Home</a> </div></div>
+{% for post in posts.posts %}
+  {% if loop.index is equalto 1 %}
+<div class="thread" id="t{{ post.no }}">
+  <div class="postContainer opContainer" id="pc{{ post.no }}">
+    <div id="p{{ post.no }}" class="post op">
+      <div class="file" id="f{{ post.no }}">
+        <div class="fileText" id="fT{{ post.no }}">File: <a href="images/{{ post.tim }}{{ post.ext }}" target="_blank">{{ post.filename|truncate(30, true, '(...)') }}{{ post.ext }}</a> ({{ post.fsize|filesizeformat }}, {{ post.h }}x{{ post.w }})</div>
+          <a class="fileThumb" href="images/{{ post.tim }}{{ post.ext }}" target="_blank">
+            <img src="thumbs/{{ post.tim }}s.jpg" alt="{{ post.fsize|filesizeformat }}" data-md5="{{ post.md5 }}" style="height: {{ post.tn_h }}px; width: {{ post.tn_w }}px;">
+          </a>
+      </div>
+      <div class="postInfo desktop" id="pi{{ post.no }}">
+        <input type="checkbox" name="" value="delete">
+        <span class="subject">{% if post.sub is defined %}{{ post.sub }}{% endif %}</span>
+        <span class="nameBlock"><span class="name">{{ post.name }}</span>
+        <span class="dateTime" data-utc="{{ post.time }}">{{ post.now }}</span>
+        <span class="postNum desktop"><a href="#p{{ post.no }}" title="Link to this post">No.</a>
+        <a href="" title="Reply to this post">{{ post.no }}</a></span></div>    
+        <blockquote class="postMessage" id="m{{ post.no }}">{{ post.com }}</blockquote>
+      </div>
+    </div>
+  {% else %}
+  <div class="postContainer replyContainer" id="pc{{ post.no }}">
+    <div class="sideArrows" id="sa{{ post.no }}">&gt;&gt;</div>
+      <div id="p{{ post.no }}" class="post reply">
+        <div class="postInfo desktop" id="pi{{ post.no }}">
+          <input type="checkbox" name="" value="delete">
+          <span class="nameBlock"><span class="name">{{ post.name }}</span>
+          <span class="dateTime" data-utc="{{ post.time }}">{{ post.now }}</span>
+          <span class="postNum desktop"><a href="#p{{ post.no }}" title="Link to this post">No.</a>
+          <a href="" title="Reply to this post">{{ post.no }}</a></span></div>
+          {% if post.filename is defined %}
+            <div class="file" id="f{{ post.no }}">
+              <div class="fileText" id="fT{{ post.no }}">File: <a href="images/{{ post.tim }}{{ post.ext }}" target="_blank">{{ post.filename|truncate(30, true, '(...)') }}{{ post.ext }}</a> ({{ post.fsize|filesizeformat }}, {{ post.h }}x{{ post.w }})</div>
+              <a class="fileThumb" href="images/{{ post.tim }}{{ post.ext }}" target="_blank">
+                <img src="thumbs/{{ post.tim }}s.jpg" alt="{{ post.fsize|filesizeformat }}" data-md5="{{ post.md5 }}" style="height: {{ post.tn_h }}px; width: {{ post.tn_w }}px;">
+              </a>
+            </div>
+          {% endif %}
+          <blockquote class="postMessage" id="m{{ post.no }}">{{ post.com }}</blockquote>
+        </div>
+      </div>
+  {% endif %}
+{% endfor %}
+</div>
+</div>
+</div>
+</body>

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ setup(
         'basc_archiver': 'basc_archiver',
         'basc_archiver.sites': 'basc_archiver/sites',
     },
-    install_requires=['requests', 'docopt==0.5.0', 'BASC-py4chan>=0.5.5'],
+    package_data = {
+        'basc_archiver.sites': ['templates/*']
+    },
+    install_requires=['requests', 'docopt==0.5.0', 'BASC-py4chan>=0.5.5', 'jinja2', 'django-htmlmin'],
     keywords='4chan downloader images json dump',
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/thread-archiver
+++ b/thread-archiver
@@ -37,6 +37,7 @@ Options:
   --follow-children              Follow threads linked in downloaded threads
   --follow-to-other-boards       Follow linked threads, even if from other boards
   --silent                       Suppresses mundane printouts, prints what's important
+  --jinja2                       Use new jinja2 templating instead of downloading HTML
   -v --verbose                   Printout more information than normal
   -h --help                      Show help
   -V --version                   Show version
@@ -58,7 +59,8 @@ if __name__ == '__main__':
                       skip_js=args['--nojs'],
                       skip_css=args['--nocss'],
                       follow_child_threads=args['--follow-children'],
-                      follow_to_other_boards=args['--follow-to-other-boards'],)
+                      follow_to_other_boards=args['--follow-to-other-boards'],
+                      jinja2=args['--jinja2'],)
     archiver = Archiver(options)
 
     print('Starting download')


### PR DESCRIPTION
I have jinja2 templates functional, but definitely not complete yet.

I will list the current issues:  
* I had to change the folder structure to get the js to work  
* I don't know how to distribute the css/js for use with the templates  
* The template itself is missing somethings (ex: no title, no theme changer)  
* It still needs to be hosted on a web server for the js to work

That's all I can specifically remember as issues, but I'm opening this pull request so that we can discuss our options, and work on fixing the issues.